### PR TITLE
Added AddUsageAware overload with IServiceProvider parameter

### DIFF
--- a/src/softaware.UsageAware.ApplicationInsights.AspNetCore/UsageAwareMiddleware.cs
+++ b/src/softaware.UsageAware.ApplicationInsights.AspNetCore/UsageAwareMiddleware.cs
@@ -20,5 +20,18 @@ namespace Microsoft.AspNetCore.Builder
 
             return services;
         }
+
+        public static IServiceCollection AddUsageAware(this IServiceCollection services, Func<IServiceProvider, UsageAwareContext> contextProvider)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            services.AddSingleton<ITelemetryInitializer>(s => new UsageAwareTelemetryInitializer(() => contextProvider(s)));
+            services.AddScoped<IUsageAwareLogger, UsageAwareLogger>();
+
+            return services;
+        }
     }
 }

--- a/src/softaware.UsageAware.ApplicationInsights.AspNetCore/softaware.UsageAware.ApplicationInsights.AspNetCore.csproj
+++ b/src/softaware.UsageAware.ApplicationInsights.AspNetCore/softaware.UsageAware.ApplicationInsights.AspNetCore.csproj
@@ -2,21 +2,21 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <Authors>softaware gmbh</Authors>
     <Company>softaware gmbh</Company>
     <Description>UsageAware is a library for tracking user actions in an application. This package contains an ASP.NET Core middleware for logging the events to Application Insights.</Description>
     <Copyright>softaware gmbh</Copyright>
     <Product>UsageAware</Product>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <FileVersion>3.0.0.0</FileVersion>
+    <FileVersion>3.1.0.0</FileVersion>
     <PackageTags>softaware, usage, track, ApplicationInsights</PackageTags>
     <PackageProjectUrl>https://github.com/softawaregmbh/library-usageaware</PackageProjectUrl>
     <RepositoryUrl>https://github.com/softawaregmbh/library-usageaware</RepositoryUrl>
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>Version 3.0.0 supports ASP.NET Core 3.1</PackageReleaseNotes>
+    <PackageReleaseNotes>Version 3.1.0 adds an AddUsageAware overload with an IServiceProvider parameter.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/softaware.UsageAware.UI.WebApp/Startup.cs
+++ b/src/softaware.UsageAware.UI.WebApp/Startup.cs
@@ -1,17 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Security.Claims;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.HttpsPolicy;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace softaware.UsageAware.UI.WebApp
 {
@@ -28,7 +23,12 @@ namespace softaware.UsageAware.UI.WebApp
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddSingleton<ITelemetryInitializer, EnvironmentTelemetryInitializer>();
-            services.AddUsageAware(() => new UsageAwareContext("demo-user", "demo-tenant"));
+            //services.AddUsageAware(() => new UsageAwareContext("demo-user", "demo-tenant"));
+            services.AddUsageAware(s =>
+            {
+                var httpContext = s.GetRequiredService<IHttpContextAccessor>().HttpContext;
+                return new UsageAwareContext(httpContext?.User?.Identity?.Name ?? "demo-user", "demo-tenant");
+            });
             services.AddApplicationInsightsTelemetry();
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
         }


### PR DESCRIPTION
Until now, if you wanted to resolve a service in the function that provides the `UsageAwareContext`, you needed to do something like this:

```csharp
var serviceProvider = new Lazy<IServiceProvider>(() => services.BuildServiceProvider());
services.AddUsageAware(() =>
{
    var principal = serviceProvider.Value.GetService<ClaimsPrincipal>();
    var userId = principal?.Claims.SingleOrDefault(c => c.Type == ClaimTypes.NameIdentifier)?.Value;
    return new UsageAwareContext(userId);
});
```

This causes a [warning](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection?view=aspnetcore-5.0#ASP0000) because a second `IServiceProvider` is created.

Using the new overload resolves this (no pun intended):

```csharp
services.AddUsageAware(s =>
{
    var principal = s.GetRequiredService<ClaimsPrincipal>();
    var userId = principal?.Claims.SingleOrDefault(c => c.Type == ClaimTypes.NameIdentifier)?.Value;
    return new UsageAwareContext(userId);
 });
```